### PR TITLE
Added handle method on migration command

### DIFF
--- a/src/Can/Commands/CanMigrationsCommand.php
+++ b/src/Can/Commands/CanMigrationsCommand.php
@@ -11,6 +11,11 @@ class CanMigrationsCommand extends Command {
 	protected $name = 'can:migration';
 
 	protected $description = 'Create migrations for the Can package';
+	
+	public function handle()
+    	{
+        	$this->fire();
+    	}
 
 	public function fire()
 	{


### PR DESCRIPTION
Starts at laravel 5.5 migration console command is now looking for handle method instead of fire method